### PR TITLE
change http verb for parcel cancel

### DIFF
--- a/server/specs/parcels.js
+++ b/server/specs/parcels.js
@@ -53,15 +53,17 @@ describe('Test case for the "parcel" resource endpoints', () => {
       });
   });
   it('should cancel a specific parcel delivery order', (done) => {
-    request.delete('/api/v1/parcels/1')
+    request.put('/api/v1/parcels/1')
+      .send({ status: 'cancelled' })
       .expect(200)
       .end((err, res) => {
         expect(res.body.message).to.equal('success');
+        expect(res.body.data.status).to.equal('cancelled');
         done();
       });
   });
-  it('should return message when record is not found for DELETE parcels/:orderId end point', (done) => {
-    request.delete('/api/v1/parcels/0')
+  it('should return message when record is not found for PUT parcels/:orderId end point', (done) => {
+    request.put('/api/v1/parcels/0')
       .expect(400)
       .end((err, res) => {
         expect(res.body.message).to.equal('NotFound');

--- a/server/v1/controllers/ParcelController.js
+++ b/server/v1/controllers/ParcelController.js
@@ -83,8 +83,9 @@ class ParcelController {
    * @param {Object} res - response object
    * @returns {Object} response object
    */
-  static cancel(req, res) {
+  static update(req, res) {
     let { orderId } = req.params;
+    const updateData = req.body;
     orderId = Number(orderId);
     const parcel = Parcel.findById(orderId);
 
@@ -94,13 +95,11 @@ class ParcelController {
       });
     }
 
-    // orders are never deleted, the status is only changed to "cancelled"
-    parcel.status = 'cancelled';
-    const cancelledParcel = Parcel.update(orderId, parcel);
+    const updatedParcel = Parcel.update(orderId, updateData);
 
     return res.status(200).json({
       message: 'success',
-      data: cancelledParcel,
+      data: updatedParcel,
     });
   }
 }

--- a/server/v1/routes/parcel.js
+++ b/server/v1/routes/parcel.js
@@ -6,6 +6,6 @@ const parcelRoutes = Router();
 parcelRoutes.get('/', ParcelController.list);
 parcelRoutes.post('/', ParcelController.store);
 parcelRoutes.get('/:orderId', ParcelController.show);
-parcelRoutes.delete('/:orderId', ParcelController.cancel);
+parcelRoutes.put('/:orderId', ParcelController.update);
 
 export default parcelRoutes;


### PR DESCRIPTION
#### What does this PR do?
- Change the HTTP Verb for handling parcel delivery cancel to PUT 
#### Description of Task to be completed?
- update parcel route 
- update tests
#### How should this be manually tested?
- pull branch and run _npm run test_
#### Any background context you want to provide?
- I had an oversight with the specs, used _delete_ instead of _put_
#### What are the relevant pivotal tracker stories?
- https://www.pivotaltracker.com/story/show/161751206