### PR TITLE
Implement order cancel correctly

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+repo_token: UR07G4Ryg8NF0e1zss0AacyONUcC8MZyo

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 /node_modules
 .nyc_output
 .env
-.coveralls.yml
 .vscode
 coverage
 yarn.lock

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "babel-node server/index.js",
     "start:dev": "nodemon --exec babel-node server",
-    "test": "set NODE_ENV=test&& nyc mocha --timeout 500000 --exit server/specs",
+    "test": "set NODE_ENV=test&& nyc mocha --timeout 300000 --exit server/specs",
     "lint": "eslint --fix server",
     "coverage": "nyc report --reporter=text-lcov | coveralls"
   },

--- a/server/specs/parcels.js
+++ b/server/specs/parcels.js
@@ -52,6 +52,23 @@ describe('Test case for the "parcel" resource endpoints', () => {
         done();
       });
   });
+  it('should cancel a specific parcel delivery order', (done) => {
+    request.put('/api/v1/parcels/1/cancel')
+      .expect(200)
+      .end((err, res) => {
+        expect(res.body.message).to.equal('success');
+        expect(res.body.data.status).to.equal('cancelled');
+        done();
+      });
+  });
+  it('should return message when record is not found for PUT parcels/:id/cancel end point', (done) => {
+    request.put('/api/v1/parcels/0/cancel')
+      .expect(400)
+      .end((err, res) => {
+        expect(res.body.message).to.equal('NotFound');
+        done();
+      });
+  });
   it('should update a specific parcel delivery order', (done) => {
     request.put('/api/v1/parcels/1')
       .send({ status: 'delivered' })

--- a/server/specs/parcels.js
+++ b/server/specs/parcels.js
@@ -44,7 +44,7 @@ describe('Test case for the "parcel" resource endpoints', () => {
         done();
       });
   });
-  it('should return message when record is not found for GET parcels/:orderId end point', (done) => {
+  it('should return message when record is not found for GET parcels/:id end point', (done) => {
     request.get('/api/v1/parcels/0')
       .expect(400)
       .end((err, res) => {
@@ -52,17 +52,17 @@ describe('Test case for the "parcel" resource endpoints', () => {
         done();
       });
   });
-  it('should cancel a specific parcel delivery order', (done) => {
+  it('should update a specific parcel delivery order', (done) => {
     request.put('/api/v1/parcels/1')
-      .send({ status: 'cancelled' })
+      .send({ status: 'delivered' })
       .expect(200)
       .end((err, res) => {
         expect(res.body.message).to.equal('success');
-        expect(res.body.data.status).to.equal('cancelled');
+        expect(res.body.data.status).to.equal('delivered');
         done();
       });
   });
-  it('should return message when record is not found for PUT parcels/:orderId end point', (done) => {
+  it('should return message when record is not found for PUT parcels/:id end point', (done) => {
     request.put('/api/v1/parcels/0')
       .expect(400)
       .end((err, res) => {

--- a/server/specs/parcels.js
+++ b/server/specs/parcels.js
@@ -1,4 +1,4 @@
-import { describe, it, before } from 'mocha';
+import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import supertest from 'supertest';
 import app from '../app';

--- a/server/v1/controllers/ParcelController.js
+++ b/server/v1/controllers/ParcelController.js
@@ -13,7 +13,7 @@ class ParcelController {
    * @param {Object} res - response object
    * @returns {Object} response object
    */
-  static list(req, res) {
+  static getAll(req, res) {
     const allRecords = Parcel.getAll();
 
     return res.status(200).json({
@@ -44,7 +44,7 @@ class ParcelController {
    * @param {Object} res - response object
    * @returns {Object} response object
    */
-  static store(req, res) {
+  static create(req, res) {
     const newParcelData = req.body;
     // as parcel orders are created, they are initially given a status of 'pending'
     newParcelData.status = 'pending';
@@ -61,7 +61,7 @@ class ParcelController {
    * @param {Object} res - response object
    * @returns {Object} response object
    */
-  static show(req, res) {
+  static getOne(req, res) {
     let { orderId } = req.params;
     orderId = Number(orderId);
     const parcel = Parcel.findById(orderId);

--- a/server/v1/controllers/ParcelController.js
+++ b/server/v1/controllers/ParcelController.js
@@ -102,6 +102,32 @@ class ParcelController {
       data: updatedParcel,
     });
   }
+
+  /**
+   * @param {Object} req - request received
+   * @param {Object} res - response object
+   * @returns {Object} response object
+   */
+  static cancel(req, res) {
+    let { orderId } = req.params;
+    const updateData = req.body;
+    orderId = Number(orderId);
+    const parcel = Parcel.findById(orderId);
+
+    if (!parcel) {
+      return res.status(400).json({
+        message: 'NotFound',
+      });
+    }
+
+    updateData.status = 'cancelled';
+    const updatedParcel = Parcel.update(orderId, updateData);
+
+    return res.status(200).json({
+      message: 'success',
+      data: updatedParcel,
+    });
+  }
 }
 
 export default ParcelController;

--- a/server/v1/routes/parcel.js
+++ b/server/v1/routes/parcel.js
@@ -7,5 +7,6 @@ parcelRoutes.get('/', ParcelController.getAll);
 parcelRoutes.post('/', ParcelController.create);
 parcelRoutes.get('/:orderId', ParcelController.getOne);
 parcelRoutes.put('/:orderId', ParcelController.update);
+parcelRoutes.put('/:orderId/cancel', ParcelController.cancel);
 
 export default parcelRoutes;

--- a/server/v1/routes/parcel.js
+++ b/server/v1/routes/parcel.js
@@ -3,9 +3,9 @@ import ParcelController from '../controllers/ParcelController';
 
 const parcelRoutes = Router();
 
-parcelRoutes.get('/', ParcelController.list);
-parcelRoutes.post('/', ParcelController.store);
-parcelRoutes.get('/:orderId', ParcelController.show);
+parcelRoutes.get('/', ParcelController.getAll);
+parcelRoutes.post('/', ParcelController.create);
+parcelRoutes.get('/:orderId', ParcelController.getOne);
 parcelRoutes.put('/:orderId', ParcelController.update);
 
 export default parcelRoutes;


### PR DESCRIPTION
#### What does this PR do?
- Correctly implement the route for cancelling orders using the specs.
#### Description of Task to be completed?
- Using the route PUT /parcels/:orderId to cancel an order was off the requirement. It should be made to use the route: PUT /parcels/:orderId/cancel.
#### How should this be manually tested?
- pull branch and run _npm run test_
#### Any background context you want to provide?
None
#### What are the relevant pivotal tracker stories?
- https://www.pivotaltracker.com/story/show/161912320
#### Screenshots (if appropriate)
None
#### Questions:`
None