### PR TITLE
Add feature user can get just their own parcels

### DIFF
--- a/server/specs/parcels.js
+++ b/server/specs/parcels.js
@@ -7,6 +7,7 @@ const request = supertest(app);
 
 describe('Test case for the "parcel" resource endpoints', () => {
   let authToken = '';
+  let authUser = {};
   let adminToken = '';
   let authToken2 = '';
   let parcel = {};
@@ -21,6 +22,7 @@ describe('Test case for the "parcel" resource endpoints', () => {
       .expect(200)
       .end((err, res) => {
         authToken = res.body.data.token;
+        authUser = res.body.data.data;
       });
     // prepare client2 authToken for accessing unowned resource
     request.post('/api/v1/auth/login')
@@ -161,17 +163,6 @@ describe('Test case for the "parcel" resource endpoints', () => {
         done();
       });
   });
-  it('should return records for seleted user', (done) => {
-    request.get('/api/v1/users/2/parcels')
-      .set('x-access-token', authToken)
-      .expect(200)
-      .end((err, res) => {
-        expect(res.body.data.length > 0).to.equal(true);
-        expect(res.body.status).to.equal('success');
-        done();
-      });
-  });
-
   describe('Change parcel destinations', () => {
     it('should change parcel destination', (done) => {
       request.put(`/api/v1/parcels/${parcel.id}/destination`)
@@ -240,6 +231,26 @@ describe('Test case for the "parcel" resource endpoints', () => {
         .end((err, res) => {
           expect(res.body.status).to.equal('Unauthorised');
           expect(res.body.message).to.equal('You lack privileges to access resource');
+          done();
+        });
+    });
+  });
+  describe('User can view all parcel delivery orders', () => {
+    it('should return user parcels', (done) => {
+      request.get(`/api/v1/users/${authUser.id}/parcels`)
+        .set('x-access-token', authToken)
+        .expect(200)
+        .end((err, res) => {
+          expect(res.body.status).to.equal('success');
+          done();
+        });
+    });
+    it('should return unauthorised when trying to access another users parcel', (done) => {
+      request.get(`/api/v1/users/${authUser.id}/parcels`)
+        .set('x-access-token', authToken2)
+        .expect(401)
+        .end((err, res) => {
+          expect(res.body.status).to.equal('Unauthorised');
           done();
         });
     });

--- a/server/v1/middlewares/Roles.js
+++ b/server/v1/middlewares/Roles.js
@@ -42,6 +42,25 @@ class Roles {
       return Response.unauthorised(res);
     }
   }
+
+  /**
+   * @static
+   * @param {Object} req - request received
+   * @param {Object} res - response retunred
+   * @param {Object} next - next middleware
+   * @return {Object} - response with error messages
+   */
+  static async isRightUser(req, res, next) {
+    const user = req.decoded;
+    const { userId } = req.params;
+    const isRightUser = user.id === Number(userId);
+
+    if (isRightUser) {
+      next();
+    } else {
+      return Response.unauthorised(res);
+    }
+  }
 }
 
 export default Roles;

--- a/server/v1/routes/user.js
+++ b/server/v1/routes/user.js
@@ -8,6 +8,7 @@ const userRoutes = Router();
 userRoutes.get(
   '/:userId/parcels',
   JWT.authenticate,
+  Roles.isRightUser,
   ParcelController.listForUser,
 );
 


### PR DESCRIPTION
#### What does this PR do?
- Add the _change parcel order status_ feature 
#### Description of Task to be completed?
- Create the middlewares to enforce input validations and permission checks
- Create controller methods to implement feature
- Write test cases for the end point
#### How should this be manually tested?
- pull branch
- Login as admin using request body of `{email: 'jaden@example.io', password: 'secret'}`
- using Postman request `GET /users/3/parcels`
#### Any background context you want to provide?
- None
#### What are the relevant pivotal tracker stories?
- https://www.pivotaltracker.com/story/show/161938432
#### Screenshots (if appropriate)
None
#### Questions:`
None