### PR TITLE
Bug handle wrong request param values 162012500

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,6 +9,7 @@ module.exports = {
 		"consistent-return": 0,
 		"no-loop-func": 0,
 		"operator-assignment": 0,
+		"no-restricted-globals": 0,
 		"no-shadow": 0,
 		"curly": ["error", "multi-line"],
     "valid-jsdoc": ["error", {

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "SendIT is a courier service that helps users deliver parcels to different destinations. SendIT provides courier quotes based on weight categories.",
   "scripts": {
     "start": "npm run db:migrate:reset && npm run db:seed && babel-node server/index.js",
-    "start:dev": "set DEBUG=database&& npm run db:migrate:reset && npm run db:seed && nodemon --exec babel-node server",
-    "test": "set NODE_ENV=test&& npm run db:migrate:reset && npm run db:seed && nyc mocha --timeout 300000 --exit server/specs",
-    "test:dev": "set NODE_ENV=test&& nyc mocha --timeout 300000 --exit server/specs",
+    "start:dev": "npm run db:migrate:reset && npm run db:seed && nodemon --exec babel-node server",
+    "test": "set NODE_ENV=test&& npm run db:migrate:reset && npm run db:seed && nyc mocha --timeout 300000 --exit server/specs/",
+    "test:dev": "set NODE_ENV=test&& nyc mocha --timeout 300000 --exit server/specs/",
     "db:migrate": "babel-node server/migrations/dbMigrate.js",
     "db:migrate:reset": "babel-node server/migrations/dbMigrateReset.js",
     "db:seed": "babel-node server/seeders/Seeder.js",
@@ -39,7 +39,8 @@
     "sourceMap": false,
     "instrument": false,
     "exclude": [
-      "server/database/config.js"
+      "server/database/config.js",
+      "server/specs"
     ]
   },
   "dependencies": {

--- a/server/migrations/Migration.js
+++ b/server/migrations/Migration.js
@@ -93,7 +93,7 @@ export default class Migration {
     if (attribute.references !== undefined) {
       fieldRow += ` REFERENCES ${attribute.on}(${attribute.references}) `;
     }
-    if (attribute.nullable !== undefined) {
+    if (attribute.notNull === true) {
       fieldRow += ' NOT NULL ';
     }
     if (attribute.default === 'currentTime') {

--- a/server/migrations/users.js
+++ b/server/migrations/users.js
@@ -9,6 +9,7 @@ const userSchema = {
     { name: 'userType', type: 'string', length: 20 },
     { name: 'email', type: 'string', length: 100 },
     { name: 'password', type: 'string', length: 100 },
+    { name: 'active', type: 'integer' },
     { name: 'createdAt', type: 'timestamp', default: 'currentTime' },
     { name: 'updatedAt', type: 'timestamp', default: 'currentTime' },
   ],

--- a/server/models/Model.js
+++ b/server/models/Model.js
@@ -76,7 +76,7 @@ class Model {
         const foundAttribute = this.schema.attributes.find(item => item.name === attribute);
         if (foundAttribute) {
           let value;
-          if (foundAttribute.type !== 'integer') {
+          if (foundAttribute.type !== 'integer' && foundAttribute.autoIncrement === undefined) {
             value = `'${this.whereConstraints[attribute]}'`;
           } else {
             value = this.whereConstraints[attribute];
@@ -93,7 +93,6 @@ class Model {
         count += 1;
       }
     }
-
 
     return whereString;
   }
@@ -180,9 +179,9 @@ class Model {
     const fieldList = [];
     const fieldValues = [];
     for (let field in data) {
-      if (field) {
+      if (this.schema.attributes.find(item => item.name === field)) {
         const foundAttribute = this.schema.attributes.find(item => item.name === field);
-        if (foundAttribute) {
+        if (foundAttribute.autoIncrement === undefined) {
           let value;
           if (foundAttribute.type !== 'integer') {
             value = `'${data[field]}'`;
@@ -225,6 +224,7 @@ class Model {
         }
       }
     }
+    // console.log(`--------${preparedSetString}--------`);
     return preparedSetString;
   }
 

--- a/server/specs/auth.js
+++ b/server/specs/auth.js
@@ -21,6 +21,18 @@ describe('Test case for the "auth" resource endpoints', () => {
         done();
       });
   });
+  it('should return error message on missing SIGNUP input', (done) => {
+    const newUserData = {
+      email: 'jaden@example.io',
+    };
+    request.post('/api/v1/auth/signup')
+      .send(newUserData)
+      .expect(422)
+      .end((err, res) => {
+        expect(res.body.status).to.equal('Unprocessable Entity');
+        done();
+      });
+  });
   it('should process login', (done) => {
     const newUserData = {
       email: 'jaden@example.io',
@@ -30,15 +42,38 @@ describe('Test case for the "auth" resource endpoints', () => {
       .send(newUserData)
       .expect(200)
       .end((err, res) => {
-        expect(res.body.data.data.id !== undefined).to.equal(true);
+        expect(res.body.data.id !== undefined).to.equal(true);
         expect(res.body.status).to.equal('success');
         done();
       });
   });
-  it('should return unauthorised when wrong login credentials are supplied', (done) => {
+  it('should return error message on missing LOGIN input', (done) => {
     const newUserData = {
+      email: 'jaden@example.io',
+    };
+    request.post('/api/v1/auth/login')
+      .send(newUserData)
+      .expect(422)
+      .end((err, res) => {
+        expect(res.body.status).to.equal('Unprocessable Entity');
+        done();
+      });
+  });
+  it('should return unauthorised when wrong login credentials are supplied', (done) => {
+    let newUserData = {
       email: 'jaden@example.ioo',
       password: 'secret',
+    };
+    request.post('/api/v1/auth/login')
+      .send(newUserData)
+      .expect(400)
+      .end((err, res) => {
+        expect(res.body.status).to.equal('Wrong Credentials');
+        expect(res.body.message).to.equal('Provide correct login credentials');
+      });
+    newUserData = {
+      email: 'jaden@example.io',
+      password: 'sssasas',
     };
     request.post('/api/v1/auth/login')
       .send(newUserData)

--- a/server/specs/parcels.js
+++ b/server/specs/parcels.js
@@ -264,6 +264,16 @@ describe('Test case for the "parcel" resource endpoints', () => {
           done();
         });
     });
+    it('should return notFound if parcel is not found', (done) => {
+      request.put('/api/v1/parcels/0/status')
+        .set('x-access-token', adminToken)
+        .send({ status: 'delivered' })
+        .expect(404)
+        .end((err, res) => {
+          expect(res.body.status).to.equal('NotFound');
+          done();
+        });
+    });
     it('should return unprocessable entity request has missing required input', (done) => {
       request.put(`/api/v1/parcels/${parcel.id}/status`)
         .set('x-access-token', adminToken)

--- a/server/specs/test.js
+++ b/server/specs/test.js
@@ -2,11 +2,11 @@ import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import supertest from 'supertest';
 import app from '../app';
-// import modelTests from './units/model';
+import modelTests from './units/model';
 
 const request = supertest(app);
 
-// modelTests();
+modelTests();
 
 describe('Test cases for the API landing routes', () => {
   it('should load the root route', (done) => {

--- a/server/v1/controllers/AuthController.js
+++ b/server/v1/controllers/AuthController.js
@@ -39,9 +39,12 @@ class AuthController {
 
     const user = await User.findByAttribute('email', email);
     let foundCredentials = false;
-    if (user) {
-      foundCredentials = bcrypt.compareSync(password, user.password);
+
+    if (!user) {
+      return Response.wrongCredentials(res);
     }
+
+    foundCredentials = bcrypt.compareSync(password, user.password);
 
     if (!foundCredentials) {
       return Response.wrongCredentials(res);
@@ -56,10 +59,9 @@ class AuthController {
     const token = jwt.sign(payload, process.env.JWT_SECRET_KEY, { expiresIn: 60 * 60 * 1 });
     req.token = token;
 
-    const data = {
-      data: payload,
-      token,
-    };
+
+    const data = payload;
+    data.token = token;
 
     return Response.success(res, data);
   }

--- a/server/v1/controllers/ParcelController.js
+++ b/server/v1/controllers/ParcelController.js
@@ -28,7 +28,7 @@ class ParcelController {
   static async listForUser(req, res) {
     let { userId } = req.params;
     userId = Number(userId);
-    const allRecords = await Parcel.where({ userId }).getAll();
+    const allRecords = await Parcel.where({ userId, status: 'pending_delivery' }).getAll();
 
     return Response.success(res, allRecords);
   }

--- a/server/v1/controllers/ParcelController.js
+++ b/server/v1/controllers/ParcelController.js
@@ -116,11 +116,6 @@ class ParcelController {
     let { parcelId } = req.params;
     const updateData = req.body;
     parcelId = Number(parcelId);
-    const parcel = await Parcel.findById(parcelId);
-
-    if (!parcel) {
-      return Response.notFound(res);
-    }
 
     const updatedParcel = await Parcel.update(parcelId, updateData);
 

--- a/server/v1/middlewares/RequestParam.js
+++ b/server/v1/middlewares/RequestParam.js
@@ -15,6 +15,7 @@ class RequestParam {
    */
   static validateParams(req, res, next) {
     for (const param in req.params) {
+      /* istanbul ignore else  */
       if (param) {
         const paramHasId = param.search(/id/i) !== -1;
         const paramValue = req.params[param];

--- a/server/v1/middlewares/RequestParam.js
+++ b/server/v1/middlewares/RequestParam.js
@@ -1,0 +1,29 @@
+import Response from '../utils/Response';
+
+/** Validate the request Params
+ * For example wherever we have /:someResourceId
+ * @export
+ * @class
+ */
+class RequestParam {
+  /**
+   * @static
+   * @param {Object} req - request received
+   * @param {Object} res - response to be returned
+   * @param {Object} next - next middleware
+   * @return {Object} - response with error messages
+   */
+  static validateParams(req, res, next) {
+    for (const param in req.params) {
+      if (param) {
+        const paramHasId = param.search(/id/i) !== -1;
+        const paramValue = req.params[param];
+        if (paramHasId && isNaN(paramValue)) {
+          return Response.wrongParamType(res);
+        }
+      }
+    }
+    next();
+  }
+}
+export default RequestParam;

--- a/server/v1/middlewares/Roles.js
+++ b/server/v1/middlewares/Roles.js
@@ -34,6 +34,11 @@ class Roles {
   static async isParcelOwner(req, res, next) {
     const user = req.decoded;
     const { parcelId } = req.params;
+    const parcel = await Parcel.findById(parcelId);
+    if (!parcel) {
+      return Response.notFound(res);
+    }
+
     const foundParcel = await Parcel.where({ userId: user.id, id: parcelId }).getOne();
 
     if (foundParcel) {

--- a/server/v1/routes/parcel.js
+++ b/server/v1/routes/parcel.js
@@ -3,20 +3,28 @@ import ParcelController from '../controllers/ParcelController';
 import JWT from '../middlewares/JWT';
 import Roles from '../middlewares/Roles';
 import ParcelValidator from '../middlewares/inputValidation/parcels';
-
+import RequestParam from '../middlewares/RequestParam';
 
 const parcelRoutes = Router();
 
-parcelRoutes.get('/', JWT.authenticate, ParcelController.getAll);
+parcelRoutes.get('/', JWT.authenticate, Roles.isAdmin, ParcelController.getAll);
 
 parcelRoutes.post('/', JWT.authenticate, ParcelValidator.validateCreate, ParcelController.create);
 
-parcelRoutes.get('/:parcelId', JWT.authenticate, ParcelController.getOne);
-parcelRoutes.put('/:parcelId', JWT.authenticate, ParcelController.update);
-parcelRoutes.put('/:parcelId/cancel', JWT.authenticate, ParcelController.cancel);
+parcelRoutes.get('/:parcelId', RequestParam.validateParams, JWT.authenticate, ParcelController.getOne);
+
+parcelRoutes.put('/:parcelId', RequestParam.validateParams, JWT.authenticate, ParcelController.update);
+
+parcelRoutes.put(
+  '/:parcelId/cancel',
+  RequestParam.validateParams,
+  JWT.authenticate,
+  ParcelController.cancel,
+);
 
 parcelRoutes.put(
   '/:parcelId/status',
+  RequestParam.validateParams,
   JWT.authenticate,
   Roles.isAdmin,
   ParcelValidator.validateChangeStatus,
@@ -25,6 +33,7 @@ parcelRoutes.put(
 
 parcelRoutes.put(
   '/:parcelId/destination',
+  RequestParam.validateParams,
   JWT.authenticate,
   Roles.isParcelOwner,
   ParcelValidator.validateChangeDestination,
@@ -33,6 +42,7 @@ parcelRoutes.put(
 
 parcelRoutes.put(
   '/:parcelId/presentLocation',
+  RequestParam.validateParams,
   JWT.authenticate,
   Roles.isAdmin,
   ParcelValidator.validateChangePresentLocation,

--- a/server/v1/routes/user.js
+++ b/server/v1/routes/user.js
@@ -2,11 +2,13 @@ import { Router } from 'express';
 import ParcelController from '../controllers/ParcelController';
 import JWT from '../middlewares/JWT';
 import Roles from '../middlewares/Roles';
+import RequestParam from '../middlewares/RequestParam';
 
 const userRoutes = Router();
 
 userRoutes.get(
   '/:userId/parcels',
+  RequestParam.validateParams,
   JWT.authenticate,
   Roles.isRightUser,
   ParcelController.listForUser,

--- a/server/v1/utils/Response.js
+++ b/server/v1/utils/Response.js
@@ -3,16 +3,14 @@ const responses = {
     status: 'Unprocessable Entity',
     message: err.details[0].message,
   }),
-  success: (res, data) => {
-    if (data) {
-      res.status(200).send({
-        status: 'success',
-        data,
-      });
-    } else {
-      res.status(200);
-    }
-  },
+  wrongParamType: res => res.status(400).send({
+    status: 'Wrong Params',
+    message: 'One or more request parameters have invalid values',
+  }),
+  success: (res, data) => res.status(200).send({
+    status: 'success',
+    data,
+  }),
   unauthorised: res => res.status(401).send({
     status: 'Unauthorised',
     message: 'You lack privileges to access resource',


### PR DESCRIPTION
#### What does this PR do?
- Fix bug with wrong numeric param values on routes
#### Description of Task to be completed?
- Refactor Responses
- Write tests
#### How should this be manually tested?
- checkout any route with numeric param like GET /parcels/:id
- supply non numeric values eg `dds` in place of numeric `1` 
- the response should be a bad request with some message
#### Any background context you want to provide?
None
#### What are the relevant pivotal tracker stories?
- https://www.pivotaltracker.com/story/show/162012500
#### Screenshots (if appropriate)
None
#### Questions:`
None