### PR TITLE
Ch fix readme typos 162040967

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ SendIT is a courier service that helps users deliver parcels to different destin
 SendIT can be found on pivotal tracker with the link below.
 (https://www.pivotaltracker.com/n/projects/2218905)
 
-### API Enpoint
+### API Enpoints
 The API is hosted at (https://johnnysam-sendit.herokuapp.com/api/v1)
 
 ### UI Templates
@@ -65,21 +65,21 @@ https://www.pivotaltracker.com/file_attachments/93331262/download?inline=true
 <table>
 <tr><th>HTTP VERB</th><th>ENDPOINT</th><th>TASK</th></tr>
 
-<tr><td>GET</td> <td>parcel?token={{adminToken}}</td> <td> Fetch all parcel delivery orders</td></tr>
+<tr><td>GET</td> <td>parcels?token={{adminToken}}</td> <td> Fetch all parcel delivery orders</td></tr>
 
-<tr><td>POST</td> <td>parcel?token={{userToken}}</td> <td> Create a parcel delivery order </td></tr>
+<tr><td>POST</td> <td>parcels?token={{userToken}}</td> <td> Create a parcel delivery order </td></tr>
 
-<tr><td>GET</td> <td>parcel/:id?token={{ownerAuthToken}}</td> <td> Fetch a specific parcel delivery order</td></tr>
+<tr><td>GET</td> <td>parcels/:id?token={{ownerAuthToken}}</td> <td> Fetch a specific parcel delivery order</td></tr>
 
 <tr><td>GET</td> <td>users/:id/parcels?{{ownerAuthToken}}</td> <td> Fetch all parcel delivery orders by a specific user </td></tr>
 
-<tr><td>PUT</td> <td>parcel/:id/cancel?token={{ownerAuthToken}}</td> <td> Cancel the specific parcel delivery order</td></tr> 
+<tr><td>PUT</td> <td>parcels/:id/cancel?token={{ownerAuthToken}}</td> <td> Cancel the specific parcel delivery order</td></tr> 
 
-<tr><td>PUT</td> <td>parcel/:id/status?{{adminAuthToken}}</td> <td> Change the status of a parcel delivery order</td></tr>
+<tr><td>PUT</td> <td>parcels/:id/status?{{adminAuthToken}}</td> <td> Change the status of a parcel delivery order</td></tr>
 
-<tr><td>PUT</td> <td>parcel/:id/destination?token={{ownerAuthToken}}</td> <td>Change the destination of a parcel delivery order</td></tr>
+<tr><td>PUT</td> <td>parcels/:id/destination?token={{ownerAuthToken}}</td> <td>Change the destination of a parcel delivery order</td></tr>
 
-<tr><td>PUT</td> <td>parcel/:id/presentLocation?token={{ownerAuthToken}}</td> <td>Change the present location of a parcel delivery order</td></tr>
+<tr><td>PUT</td> <td>parcels/:id/presentLocation?token={{ownerAuthToken}}</td> <td>Change the present location of a parcel delivery order</td></tr>
 
 <tr><td>POST</td> <td>auth/signup</td> <td> User Signup </td></tr>
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ https://www.pivotaltracker.com/file_attachments/93331262/download?inline=true
 - run `npm run test` to test the api
 
 
-### API Endpoint Route 
+### API Endpoint Routes 
 #### NOTE: All requests are prefixed with `api/v1`
 <table>
 <tr><th>HTTP VERB</th><th>ENDPOINT</th><th>TASK</th></tr>


### PR DESCRIPTION
#### What does this PR do?
- Fix typos on README
#### Description of Task to be completed?
- On the README file, at the _Getting Started_ section, the API Endpoint Route should be _API Endpoint Routes_.
the ENDPOINT row on the Api Endpoints table has endpoints named _parcel?token..._. This should be renamed to _parcels?token..._
#### How should this be manually tested?
- pull branch and check readme for the corrections
#### Any background context you want to provide?
- None
#### What are the relevant pivotal tracker stories?
- https://www.pivotaltracker.com/story/show/162040967
#### Screenshots (if appropriate)
None
#### Questions:`
None