### PR TITLE
Add authorisation guard to all admin pages

### DIFF
--- a/src/app/index.js
+++ b/src/app/index.js
@@ -117,8 +117,8 @@ export default class App {
     // attach event handlers to elements
     let { actions } = services;
     if(adminLoginForm) { 
-      adminLoginForm.addEventListener('submit', actions.userLogin);
-      adminLoginForm.addEventListener('input', actions.saveInput.bind(this, 'userLogin'));
+      adminLoginForm.addEventListener('submit', actions.adminLogin);
+      adminLoginForm.addEventListener('input', actions.saveInput.bind(this, 'adminLogin'));
     }
     if(userLoginForm) { 
       userLoginForm.addEventListener('submit', actions.userLogin);

--- a/src/app/layouts/AdminSideBar.js
+++ b/src/app/layouts/AdminSideBar.js
@@ -1,0 +1,40 @@
+import Link from '../components/Link';
+
+const SideBar = () => {
+  return (`
+    <aside class='actions-sidebar show-for-large'>
+      <div class="header">
+        ${Link({
+          to:'/', 
+          text:`<div class="logo"><img src="/assets/img/sendit-pickup-ondemand.svg" alt="sendit-logo" /></div>
+          <div class="text">Send<span>IT</span></div>`, 
+          className: 'logo-text-group', 
+        })}
+      </div>
+      <div class="content">
+        <ul class="side-links">
+          <li>
+            ${Link({
+              to:'/admin-dashboard/all-parcels', 
+              text:`<i class=""></i>All Orders`, 
+            })}
+          </li>
+          <li>
+            ${Link({
+              to:'/admin-dashboard/pending-parcels', 
+              text:`<i class=""></i>Pending Orders`, 
+            })}
+          </li>
+          <li>
+            ${Link({
+              to:'/admin-dashboard/delivered-parcels', 
+              text:`<i class=""></i>Delivered Parcels`, 
+            })}
+          </li>
+        </ul>
+      </div>
+    </aside>
+  `);
+}
+
+export default SideBar;

--- a/src/app/pages/admin/AllParcels.js
+++ b/src/app/pages/admin/AllParcels.js
@@ -2,10 +2,17 @@ import SideBar from '../../layouts/SideBar'
 import MobileHeader from '../../layouts/MobileHeader';
 import MainPageHeader from '../../layouts/MainPageHeader';
 import Parcel from '../../components/Parcel';
+import { retrieveAuthUser } from "../../services/localStorage";
 
 export default class AdminAllParcels {
   constructor() {
     document.title = "All Parcels - Send IT - Send Parcels Anywhere | Timely Delivery | Real Time Tracking";
+    
+    // redirect user if not admin
+    const savedAuthUser = retrieveAuthUser();
+    if (! savedAuthUser || !savedAuthUser.isAdmin) {
+      window.location.href = '/admin-login';
+    }
   }
   renderProduct() {
     let productHTML = '';

--- a/src/app/pages/admin/AllParcels.js
+++ b/src/app/pages/admin/AllParcels.js
@@ -1,4 +1,4 @@
-import SideBar from '../../layouts/SideBar'
+import SideBar from '../../layouts/AdminSideBar';
 import MobileHeader from '../../layouts/MobileHeader';
 import MainPageHeader from '../../layouts/MainPageHeader';
 import Parcel from '../../components/Parcel';

--- a/src/app/pages/admin/DeliveredParcels.js
+++ b/src/app/pages/admin/DeliveredParcels.js
@@ -2,10 +2,17 @@ import SideBar from '../../layouts/SideBar'
 import MobileHeader from '../../layouts/MobileHeader';
 import MainPageHeader from '../../layouts/MainPageHeader';
 import Parcel from '../../components/Parcel';
+import { retrieveAuthUser } from "../../services/localStorage";
 
 export default class AdminDeliveredParcels {
   constructor() {
     document.title = "Delivered Parcels - Send IT - Send Parcels Anywhere | Timely Delivery | Real Time Tracking";
+
+    // redirect user if not admin
+    const savedAuthUser = retrieveAuthUser();
+    if (! savedAuthUser || !savedAuthUser.isAdmin) {
+      window.location.href = '/admin-login';
+    }
   }
   renderProduct() {
     let productHTML = '';

--- a/src/app/pages/admin/DeliveredParcels.js
+++ b/src/app/pages/admin/DeliveredParcels.js
@@ -1,4 +1,4 @@
-import SideBar from '../../layouts/SideBar'
+import SideBar from '../../layouts/AdminSideBar';
 import MobileHeader from '../../layouts/MobileHeader';
 import MainPageHeader from '../../layouts/MainPageHeader';
 import Parcel from '../../components/Parcel';

--- a/src/app/pages/admin/PendingParcels.js
+++ b/src/app/pages/admin/PendingParcels.js
@@ -1,7 +1,8 @@
-import SideBar from '../../layouts/SideBar'
+import SideBar from '../../layouts/AdminSideBar';
 import MobileHeader from '../../layouts/MobileHeader';
 import MainPageHeader from '../../layouts/MainPageHeader';
 import Parcel from '../../components/Parcel';
+import { retrieveAuthUser } from "../../services/localStorage";
 
 export default class AdminPendingParcels {
   constructor() {

--- a/src/app/pages/admin/PendingParcels.js
+++ b/src/app/pages/admin/PendingParcels.js
@@ -6,6 +6,12 @@ import Parcel from '../../components/Parcel';
 export default class AdminPendingParcels {
   constructor() {
     document.title = "Pending Parcels - Send IT - Send Parcels Anywhere | Timely Delivery | Real Time Tracking";
+
+    // redirect user if not admin
+    const savedAuthUser = retrieveAuthUser();
+    if (! savedAuthUser || !savedAuthUser.isAdmin) {
+      window.location.href = '/admin-login';
+    }
   }
   renderProduct() {
     let productHTML = '';

--- a/src/app/services/DOM.js
+++ b/src/app/services/DOM.js
@@ -1,3 +1,0 @@
-class DOM {
-  static getElem() {}
-}

--- a/src/app/services/ResponseException.js
+++ b/src/app/services/ResponseException.js
@@ -1,12 +1,10 @@
 export default class ResponseException {
-  constructor(response) {
-    ( async () => {
-      // get response body as json
-      let responseBody = await response.json();
-      // get the api message returned 
-      this.message = responseBody.message;
-      // get the status code
-      this.status = response.status;
-    })();
+  static async prepare(response) {
+    // get response body as json
+    let responseBody = await response.json();
+    // get the api message returned
+    this.message = responseBody.message;
+    this.status = response.status;
+    return this;
   }
 } 

--- a/src/app/services/actions/user.js
+++ b/src/app/services/actions/user.js
@@ -14,8 +14,33 @@ export const userLogin = (e) => {
     
     const savedAuthUser = retrieveAuthUser();
 
+    console.log('--Auth User--', savedAuthUser);
+
+  }).catch(async error => {
+    let message = await error.getMessage();
+    console.log("---ERROR", message);
+    // TODO:
+    // show some feedback on the user interface
+  });
+}
+
+export const adminLogin = (e) => {
+  e.preventDefault();
+  const data = window.app.store.adminLoginData;
+
+  api.userLogin(data).then(response => {
+    window.app.store.authUser = response.data;
+
+    const authUser = response.data;
+    
+    persistAuthUser(authUser);
+    
+    const savedAuthUser = retrieveAuthUser();
+
+    console.log('--Auth User--', savedAuthUser);
   }).catch(error => {
-    // console.log("---ERROR", error.status);
+    // let message = await error.getMessage();
+    console.log("---ERROR", error.status);
     // TODO:
     // show some feedback on the user interface
   });

--- a/src/app/services/apiRequests.js
+++ b/src/app/services/apiRequests.js
@@ -6,12 +6,12 @@ const BASE_URL = 'http://localhost:8001/api/v1';
 
 export const getParcels = (token) => {
   return fetch(`${BASE_URL}/parcels?token=${token}`)
-  .then(async res => { 
+  .then(res => { 
     if(!res.ok) {
-      throw await new ResponseException(res);
+      throw new ResponseException(res);
     }
     return res.json();
-  }); 
+  });
 }
 
 export const userLogin = (data) => {
@@ -25,7 +25,7 @@ export const userLogin = (data) => {
   })
   .then(async res => { 
     if(!res.ok) {
-      throw await new ResponseException(res);
+      throw await ResponseException.prepare(res);
     }
     return res.json();
   });
@@ -40,9 +40,9 @@ export const userSignup = (data) => {
       'Content-Type': 'application/json'
     }),
   })
-  .then(async res => { 
+  .then(res => { 
     if(!res.ok) {
-      throw await new ResponseException(res);
+      throw new ResponseException(res);
     }
     return res.json();
   })

--- a/src/app/services/index.js
+++ b/src/app/services/index.js
@@ -1,6 +1,10 @@
 import * as localStorage from './localStorage';
 import saveInput from './actions/saveInput';
-import { userLogin, userSignup } from './actions/user';
+import { 
+  userLogin, 
+  userSignup, 
+  adminLogin 
+} from './actions/user';
 
 
 export default {
@@ -8,6 +12,7 @@ export default {
   actions: {
     saveInput,
     userLogin,
+    adminLogin,
     userSignup
   }
 };

--- a/src/app/services/localStorage.js
+++ b/src/app/services/localStorage.js
@@ -1,13 +1,3 @@
-
-const getUserToken = () => {
-  const authUser = retrieveAuthUser();
-  let token = 'xxxx';
-  if(authUser) {
-    token = authUser.token;
-  }
-  return token;
-};
-
 const retrieveAuthUser = () => {
   var user = JSON.parse(localStorage.getItem('authUser'));
   return user;
@@ -19,7 +9,6 @@ const persistAuthUser = (data) => {
 
 
 export {
-  getUserToken,
   retrieveAuthUser,
   persistAuthUser
 };

--- a/src/index.js
+++ b/src/index.js
@@ -67,5 +67,4 @@ app.funcs = {
 
 
 window.app = app;
-const actions = services;
 window.app.funcs.init();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = {
   },
   devServer: {
     contentBase: './public',
-    port: 3000,
+    port: 3001,
     historyApiFallback: {
       index: 'index.html'
     }


### PR DESCRIPTION
#### What does this PR do?
- Add authorisation guard to all admin pages
#### Description of Task to be completed?
- Create Authentication services for saving and retrieving authenticated user's data
- Use user decoded data to ascertain if is admin and allow or disallow access to admin page
#### How should this be manually tested?
- pull branch and run _npm run start:dev_
- visit http://localhost:3001/admin-dashboard/all-parcels without logging in as admin
- Login as admin using  `{email: 'samcotech@example.io', password: 'secretpass'}`
- visit http://localhost:3001/admin-dashboard/all-parcels now logging in as admin
#### Any background context you want to provide?
- Non-Admin users should not be able see admin dashboard
#### What are the relevant pivotal tracker stories?
- https://www.pivotaltracker.com/story/show/162299560
#### Screenshots (if appropriate)
None
#### Questions:`
None