### PR TITLE
Fix wrong user profile data

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-	"root": true,
+  "root": true,
   "extends": "airbnb-base",
   "env": {
     "node": true,
@@ -19,8 +19,12 @@ module.exports = {
     "class-methods-use-this": 0,
     "comma-dangle": 0,
     "curly": ["error", "multi-line"],
-    "import/no-unresolved": [2, { "commonjs": true }],
-    "no-shadow": ["error", { "allow": ["req", "res", "err"] }],
+    "import/no-unresolved": [2, {
+      "commonjs": true
+    }],
+    "no-shadow": ["error", {
+      "allow": ["req", "res", "err"]
+    }],
     "valid-jsdoc": ["error", {
       "requireReturn": true,
       "requireReturnType": true,
@@ -28,11 +32,11 @@ module.exports = {
       "requireReturnDescription": true
     }],
     "require-jsdoc": ["error", {
-        "require": {
-            "FunctionDeclaration": true,
-            "MethodDefinition": true,
-            "ClassDeclaration": true
-        }
+      "require": {
+        "FunctionDeclaration": true,
+        "MethodDefinition": true,
+        "ClassDeclaration": true
+      }
     }]
   }
 };

--- a/server/v1/controllers/UserController.js
+++ b/server/v1/controllers/UserController.js
@@ -18,10 +18,10 @@ class UserController {
   static async getProfile(req, res) {
     const { userId } = req.params;
     const user = await User.findById(userId);
-    const transitingParcels = await Parcel.where({ userId, status: 'transiting' }).count();
-    const deliveredParcels = await Parcel.where({ userId, status: 'delivered' }).count();
-    const placedParcels = await Parcel.where({ userId, status: 'placed' }).count();
-    const cancelledParcels = await Parcel.where({ userId, status: 'cancelled' }).count();
+    const transitingParcels = await Parcel.where({ placedBy: userId, status: 'transiting' }).count();
+    const deliveredParcels = await Parcel.where({ placedBy: userId, status: 'delivered' }).count();
+    const placedParcels = await Parcel.where({ placedBy: userId, status: 'placed' }).count();
+    const cancelledParcels = await Parcel.where({ placedBy: userId, status: 'cancelled' }).count();
 
     delete user.password;
     delete user.isAdmin;


### PR DESCRIPTION
#### What does this PR do?
- Fix wrong user profile data
#### Description of Task to be completed?
- Fix error with WHERE constraint from the SQL query
- Fetch accurate user data
#### How should this be manually tested?
- login with request body `{email: jsamchineme@gmail.com, password: 'secretpass'}` and retrieve <token>
- hit GET /api/v1/users/{userId}?token={token}
- request GET /api/v1/users/{userId}/parcels?token={token}
- Observe that the number of parcels returned now correspond with the summative number of parcels under the namespace of the different order statuses. ie _placed, transiting, delivered, cancelled_ 
#### Any background context you want to provide?
- None
#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/162977219